### PR TITLE
Fixed angular module name in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can download angular-bootstrap-datepicker via bower:
 When you are done downloading all the dependencies and project files the only remaining part is to add dependencies as an AngularJS module:
 
 ```javascript
-angular.module('myModule', ['ng-bootstrap3-datepicker']);
+angular.module('myModule', ['ng-bs3-datepicker']);
 ```
 
 You also need to include these files:


### PR DESCRIPTION
Found a mistake in the documentation.